### PR TITLE
Hotfix - Druid combopoints

### DIFF
--- a/Elements/UnitFrames/oUF/elements/combopoints.lua
+++ b/Elements/UnitFrames/oUF/elements/combopoints.lua
@@ -42,9 +42,9 @@ end
 local UpdateScratchyBoi = function(self)
 	ShapeshiftForm = GetShapeshiftForm()
 	
-	if (ShapeshiftForm == 3 and not self.ComboPoints:IsShown()) then
+	if (ShapeshiftForm == 3) then
 		self.ComboPoints:Show()
-	elseif self:IsShown() then
+	else
 		self.ComboPoints:Hide()
 	end
 	
@@ -63,8 +63,10 @@ local Enable = function(self)
 		self:RegisterEvent("PLAYER_ENTERING_WORLD", Path, true)
 		self:RegisterEvent("UNIT_POWER_UPDATE", Path, true)
 		
-		if (vUI.UserClass == "DRUID") then
-			self:RegisterEvent("UPDATE_SHAPESHIFT_FORMS", UpdateScratchyBoi, true)
+		local playerClass = select(2, UnitClass("player"))
+
+		if (playerClass == "DRUID") then
+			self:RegisterEvent("UPDATE_SHAPESHIFT_FORM", UpdateScratchyBoi, true)
 			self:RegisterEvent("PLAYER_ENTERING_WORLD", UpdateScratchyBoi, true)
 		end
 		
@@ -90,7 +92,7 @@ local Disable = function(self)
 		self:UnregisterEvent("UNIT_POWER_UPDATE", Path)
 		
 		if self:IsEventRegistered("UPDATE_SHAPESHIFT_FORMS") then
-			self:UnregisterEvent("UPDATE_SHAPESHIFT_FORMS", UpdateScratchyBoi)
+			self:UnregisterEvent("UPDATE_SHAPESHIFT_FORM", UpdateScratchyBoi)
 			self:UnregisterEvent("PLAYER_ENTERING_WORLD", UpdateScratchyBoi)
 		end
 	end

--- a/Elements/UnitFrames/oUF/elements/combopoints.lua
+++ b/Elements/UnitFrames/oUF/elements/combopoints.lua
@@ -1,5 +1,6 @@
 local _, ns = ...
 local oUF = ns.oUF
+local vUI = ns:get()
 
 local GetShapeshiftForm = GetShapeshiftForm
 local GetComboPoints = GetComboPoints
@@ -62,10 +63,8 @@ local Enable = function(self)
 		
 		self:RegisterEvent("PLAYER_ENTERING_WORLD", Path, true)
 		self:RegisterEvent("UNIT_POWER_UPDATE", Path, true)
-		
-		local playerClass = select(2, UnitClass("player"))
 
-		if (playerClass == "DRUID") then
+		if (vUI.UserClass == "DRUID") then
 			self:RegisterEvent("UPDATE_SHAPESHIFT_FORM", UpdateScratchyBoi, true)
 			self:RegisterEvent("PLAYER_ENTERING_WORLD", UpdateScratchyBoi, true)
 		end


### PR DESCRIPTION
- Typo in event name
- Swap `vUI.UserClass` with `UnitClass` call since the former was returning `nil`
- Removed some conditionals that were hiding the combo points immediately after they were shown